### PR TITLE
Add double quotes around value in .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ NUXT_OAUTH_GITHUB_CLIENT_SECRET="my-github-oauth-app-secret"
 To create sealed sessions, you also need to add `NUXT_SESSION_SECRET` in the `.env` with at least 32 characters:
 
 ```bash
-NUXT_SESSION_SECRET=your-super-long-secret-for-session-encryption
+NUXT_SESSION_SECRET="your-super-long-secret-for-session-encryption"
 ```
 
 ## Development


### PR DESCRIPTION
This change improves clarity and accuracy in the documentation, ensuring users understand how to properly format values in the .env file.